### PR TITLE
US104058 -- Add tooltip support to tag component

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,9 @@
     "d2l-typography": "^6.0.0",
     "d2l-localize-behavior": "^1.1.2",
     "d2l-polymer-behaviors": "^1.8.0",
-    "d2l-inputs": "^1.0.2"
+    "d2l-inputs": "^1.0.2",
+    "d2l-offscreen": "^3.0.3",
+    "d2l-tooltip": "git://github.com/BrightspaceUI/tooltip#hybrid"
   },
   "devDependencies": {
     "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^2.0.0",

--- a/d2l-multi-select-list-item.html
+++ b/d2l-multi-select-list-item.html
@@ -88,14 +88,14 @@
 
 		</style>
 
-		<div class="d2l-multi-select-list-item-wrapper" on-click="_onClick">
-			<div class="d2l-multi-select-list-item-text" id="tag" aria-hidden="true">[[_getVisibleText(text,shortText,maxChars)]]</div>
+		<div class="d2l-multi-select-list-item-wrapper" id="tag" on-click="_onClick">
+			<div class="d2l-multi-select-list-item-text" aria-hidden="true">[[_getVisibleText(text,shortText,maxChars)]]</div>
 			<d2l-offscreen>[[_getScreenReaderText(text,shortText)]]</d2l-offscreen>
 			<d2l-icon icon="d2l-tier1:close-large-thick" hidden=[[!deletable]] on-click="_onDeleteItem"></d2l-icon>
-			<template is="dom-if" if="[[_hasTooltip(text,shortText,maxChars)]]">
-				<d2l-tooltip for="tag" position="[[tooltipPosition]]">[[text]]</d2l-tooltip>
-			</template>
 		</div>
+		<template is="dom-if" if="[[_hasTooltip(text,shortText,maxChars)]]">
+			<d2l-tooltip for="tag" position="[[tooltipPosition]]">[[text]]</d2l-tooltip>
+		</template>
 	</template>
 	<script>
 		/**

--- a/d2l-multi-select-list-item.html
+++ b/d2l-multi-select-list-item.html
@@ -3,6 +3,8 @@
 <link rel="import" href="../d2l-typography/d2l-typography-shared-styles.html">
 <link rel="import" href="../d2l-icons/d2l-icon.html">
 <link rel="import" href="../d2l-icons/tier1-icons.html">
+<link rel="import" href="../d2l-offscreen/d2l-offscreen.html">
+<link rel="import" href="../d2l-tooltip/d2l-tooltip.html">
 <link rel="import" href="localize-behavior.html">
 
 <dom-module id="d2l-multi-select-list-item">
@@ -87,8 +89,12 @@
 		</style>
 
 		<div class="d2l-multi-select-list-item-wrapper" on-click="_onClick">
-			<div class="d2l-multi-select-list-item-text">[[text]]</div>
-			<d2l-icon icon="d2l-tier1:close-large-thick" hidden=[[!deletable]] on-click="_onDeleteItem" />
+			<div class="d2l-multi-select-list-item-text" id="tag" aria-hidden="true">[[_getVisibleText(text,shortText,maxChars)]]</div>
+			<d2l-offscreen>[[_getScreenReaderText(text,shortText)]]</d2l-offscreen>
+			<d2l-icon icon="d2l-tier1:close-large-thick" hidden=[[!deletable]] on-click="_onDeleteItem"></d2l-icon>
+			<template is="dom-if" if="[[_hasTooltip(text,shortText,maxChars)]]">
+				<d2l-tooltip for="tag" position="[[tooltipPosition]]">[[text]]</d2l-tooltip>
+			</template>
 		</div>
 	</template>
 	<script>
@@ -111,6 +117,27 @@
 						type: String,
 						value: ''
 					},
+
+					/**
+					* Alternative text to display on the tag
+					* in place of the full text which is shown
+					* in the tooltip
+					*/
+					shortText: {
+						type: String,
+						value: null
+					},
+
+					/**
+					* Maximum number of characters to show in the
+					* tag before it is truncated and a tooltip is
+					* added
+					*/
+					maxChars: {
+						type: Number,
+						value: 40
+					},
+
 					/**
 					* Whether the multi-select-list-item can be deleted.
 					*/
@@ -118,6 +145,14 @@
 						type: Boolean,
 						value: false
 					},
+
+					/**
+					* The tooltip position
+					*/
+					tooltipPosition: {
+						type: String,
+						value: 'top'
+					}
 				};
 			}
 
@@ -129,6 +164,26 @@
 				super.connectedCallback();
 				// Set tabindex to allow focusable behaviour from the list
 				this.tabIndex = -1;
+			}
+
+			_hasTooltip(text, shortText, maxChars) {
+				return shortText || text.length > maxChars;
+			}
+
+			_getVisibleText(text, shortText, maxChars) {
+				if (shortText) {
+					return shortText;
+				}
+
+				if (text.length <= maxChars) {
+					return text;
+				}
+
+				return text.substring(0, maxChars) + '...';
+			}
+
+			_getScreenReaderText(text, shortText) {
+				return shortText || text;
 			}
 
 			_onClick() {

--- a/demo/index.html
+++ b/demo/index.html
@@ -61,8 +61,20 @@
 			<h3>d2l-multi-select-list-item</h3>
 			<demo-snippet>
 				<template>
-					<d2l-multi-select-list-item text="Default select-list-item"></d2l-multi-select-list-item>
-					<d2l-multi-select-list-item deletable text="Default select-list-item with delete"></d2l-multi-select-list-item>
+					<d2l-multi-select-list-item
+						text="Short Text"
+						deletable
+					></d2l-multi-select-list-item>
+					<d2l-multi-select-list-item
+						text="Long Truncated Text"
+						max-chars="11"
+						deletable
+					></d2l-multi-select-list-item>
+					<d2l-multi-select-list-item
+						text="Longer text for the tooltip"
+						short-text="Alternate Text"
+						deletable
+					></d2l-multi-select-list-item>
 				</template>
 			</demo-snippet>
 			<h3>d2l-multi-select-list</h3>


### PR DESCRIPTION
Adding support for tooltips. A `max-chars` property can be specified to truncate the text after a certain number of characters, and a tooltip will be displayed on hover showing the full text.
Alternatively. you can specify an alternate shorter text to display on the tag using the `short-text` property, with the `text` property only being shown in the tooltip (we will use this for Learning Outcomes that have a short form name, with the full description in a tooltip- or if no short form name exists, the description will be truncated with the full thing shown in the tooltip)

Adding this to the tag component itself to avoid issues with Polymer 3 that would happen if the tooltip were added externally.