### PR TITLE
Do not automatically remove a tag from its parent on a deletion action by default

### DIFF
--- a/d2l-multi-select-input-text.js
+++ b/d2l-multi-select-input-text.js
@@ -17,7 +17,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-input-text">
 			}
 		</style>
 
-		<d2l-multi-select-input id="d2l-multi-select-input">
+		<d2l-multi-select-input id="d2l-multi-select-input" autoremove="[[autoremove]]">
 			<slot></slot>
 			<d2l-input-text
 				aria-describedby$="[[ariaDescribedby]]"
@@ -75,6 +75,10 @@ class D2LMultiSelectInputText extends PolymerElement {
 			},
 			value: {
 				type: String,
+			},
+			autoremove: {
+				type: Boolean,
+				value: false
 			}
 		};
 	}

--- a/d2l-multi-select-input.js
+++ b/d2l-multi-select-input.js
@@ -10,7 +10,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-input">
 			}
 		</style>
 
-		<d2l-multi-select-list id="d2l-multi-select-list">
+		<d2l-multi-select-list id="d2l-multi-select-list" autoremove="[[autoremove]]">
 			<slot></slot>
 		</d2l-multi-select-list>
 		<slot name="input"></slot>
@@ -31,6 +31,19 @@ class D2LMultiSelectInput extends PolymerElement {
 
 	constructor() {
 		super();
+	}
+
+	static get properties() {
+		return {
+			/**
+			* Automatically remove this element from its parent
+			* when its remove button is clicked
+			*/
+			autoremove: {
+				type: Boolean,
+				value: false
+			}
+		};
 	}
 
 	addItem(text, ctx = this) {

--- a/d2l-multi-select-input.js
+++ b/d2l-multi-select-input.js
@@ -36,8 +36,8 @@ class D2LMultiSelectInput extends PolymerElement {
 	static get properties() {
 		return {
 			/**
-			* Automatically remove this element from its parent
-			* when its remove button is clicked
+			* Automatically remove list items when they fire a
+			* d2l-multi-select-list-item-deleted event
 			*/
 			autoremove: {
 				type: Boolean,

--- a/d2l-multi-select-list-item.js
+++ b/d2l-multi-select-list-item.js
@@ -235,9 +235,7 @@ class D2LMultiSelectItem extends mixinBehaviors(
 	}
 
 	deleteItem() {
-		if (this.autoremove) {
-			this.parentNode.removeChild(this);
-		}
+		this.parentNode.removeChild(this);
 	}
 }
 customElements.define(D2LMultiSelectItem.is, D2LMultiSelectItem);

--- a/d2l-multi-select-list-item.js
+++ b/d2l-multi-select-list-item.js
@@ -171,6 +171,15 @@ class D2LMultiSelectItem extends mixinBehaviors(
 			},
 
 			/**
+			* Automatically remove this element from its parent
+			* when its remove button is clicked
+			*/
+			autoremove: {
+				type: Boolean,
+				value: false
+			},
+
+			/**
 			 * Fallback CSS for Microsoft browsers
 			 */
 			_fallbackCss: {
@@ -226,7 +235,9 @@ class D2LMultiSelectItem extends mixinBehaviors(
 	}
 
 	deleteItem() {
-		this.parentNode.removeChild(this);
+		if (this.autoremove) {
+			this.parentNode.removeChild(this);
+		}
 	}
 }
 customElements.define(D2LMultiSelectItem.is, D2LMultiSelectItem);

--- a/d2l-multi-select-list-item.js
+++ b/d2l-multi-select-list-item.js
@@ -171,15 +171,6 @@ class D2LMultiSelectItem extends mixinBehaviors(
 			},
 
 			/**
-			* Automatically remove this element from its parent
-			* when its remove button is clicked
-			*/
-			autoremove: {
-				type: Boolean,
-				value: false
-			},
-
-			/**
 			 * Fallback CSS for Microsoft browsers
 			 */
 			_fallbackCss: {

--- a/d2l-multi-select-list.js
+++ b/d2l-multi-select-list.js
@@ -54,8 +54,8 @@ class D2LMultiSelectList extends mixinBehaviors(
 				value: null
 			},
 			/**
-			* Automatically remove this element from its parent
-			* when its remove button is clicked
+			* Automatically remove list items when they fire a
+			* d2l-multi-select-list-item-deleted event
 			*/
 			autoremove: {
 				type: Boolean,

--- a/d2l-multi-select-list.js
+++ b/d2l-multi-select-list.js
@@ -52,12 +52,21 @@ class D2LMultiSelectList extends mixinBehaviors(
 			_currentlyFocusedElement: {
 				type: Node,
 				value: null
+			},
+			/**
+			* Automatically remove this element from its parent
+			* when its remove button is clicked
+			*/
+			autoremove: {
+				type: Boolean,
+				value: false
 			}
 		};
 	}
 
 	constructor() {
 		super();
+		this._onListItemDeleted = this._onListItemDeleted.bind(this);
 	}
 
 	connectedCallback() {
@@ -104,7 +113,9 @@ class D2LMultiSelectList extends mixinBehaviors(
 	}
 
 	_onListItemDeleted(event) {
-		event.target.deleteItem();
+		if (this.autoremove) {
+			event.target.deleteItem();
+		}
 	}
 
 	_onKeyDown(event) {
@@ -126,7 +137,7 @@ class D2LMultiSelectList extends mixinBehaviors(
 					? this.__focusPrevious(rootTarget)
 					: this.__focusNext(rootTarget);
 			}
-			rootTarget.deleteItem();
+			rootTarget._onDeleteItem();
 		}
 	}
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -55,20 +55,20 @@
 			<h3>d2l-multi-select-input-text</h3>
 			<demo-snippet>
 				<template>
-					<d2l-multi-select-input-text aria-label="Multi select demo" placeholder="Press Enter to add an item">
-						<d2l-multi-select-list-item deletable="" autoremove text="Existing list item 0"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" autoremove text="Existing list item 1"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" autoremove text="Existing list item 2"></d2l-multi-select-list-item>
+					<d2l-multi-select-input-text autoremove aria-label="Multi select demo" placeholder="Press Enter to add an item">
+						<d2l-multi-select-list-item deletable="" text="Existing list item 0"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" text="Existing list item 1"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" text="Existing list item 2"></d2l-multi-select-list-item>
 					</d2l-multi-select-input-text>
 				</template>
 			</demo-snippet>
 			<h3>d2l-multi-select-input (slotted)</h3>
 			<demo-snippet>
 				<template>
-					<d2l-multi-select-input id="slotted-input-demo">
-						<d2l-multi-select-list-item deletable="" autoremove text="Existing list item 0"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" autoremove text="Existing list item 1"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" autoremove text="Existing list item 2"></d2l-multi-select-list-item>
+					<d2l-multi-select-input autoremove id="slotted-input-demo">
+						<d2l-multi-select-list-item deletable="" text="Existing list item 0"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" text="Existing list item 1"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" text="Existing list item 2"></d2l-multi-select-list-item>
 						<div class="custom-input" slot="input">
 							<input aria-label="Slotted input multi select demo" id="slotted-input-demo-input" placeholder="Press Enter or click Add to add an item"><button id="slotted-input-demo-button">Add</button>
 						</div>
@@ -86,13 +86,13 @@
 			<h3>d2l-multi-select-list</h3>
 			<demo-snippet>
 				<template>
-					<d2l-multi-select-list>
-						<d2l-multi-select-list-item deletable="" autoremove text="List item 0"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" autoremove text="List item 1"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" autoremove text="List item 2"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" autoremove text="List item 3"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" autoremove text="List item 4"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" autoremove text="List item 5"></d2l-multi-select-list-item>
+					<d2l-multi-select-list autoremove>
+						<d2l-multi-select-list-item deletable="" text="List item 0"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" text="List item 1"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" text="List item 2"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" text="List item 3"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" text="List item 4"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" text="List item 5"></d2l-multi-select-list-item>
 					</d2l-multi-select-list>
 				</template>
 			</demo-snippet>

--- a/demo/index.html
+++ b/demo/index.html
@@ -56,9 +56,9 @@
 			<demo-snippet>
 				<template>
 					<d2l-multi-select-input-text aria-label="Multi select demo" placeholder="Press Enter to add an item">
-						<d2l-multi-select-list-item deletable="" text="Existing list item 0"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" text="Existing list item 1"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" text="Existing list item 2"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" autoremove text="Existing list item 0"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" autoremove text="Existing list item 1"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" autoremove text="Existing list item 2"></d2l-multi-select-list-item>
 					</d2l-multi-select-input-text>
 				</template>
 			</demo-snippet>
@@ -66,9 +66,9 @@
 			<demo-snippet>
 				<template>
 					<d2l-multi-select-input id="slotted-input-demo">
-						<d2l-multi-select-list-item deletable="" text="Existing list item 0"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" text="Existing list item 1"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" text="Existing list item 2"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" autoremove text="Existing list item 0"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" autoremove text="Existing list item 1"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" autoremove text="Existing list item 2"></d2l-multi-select-list-item>
 						<div class="custom-input" slot="input">
 							<input aria-label="Slotted input multi select demo" id="slotted-input-demo-input" placeholder="Press Enter or click Add to add an item"><button id="slotted-input-demo-button">Add</button>
 						</div>
@@ -87,12 +87,12 @@
 			<demo-snippet>
 				<template>
 					<d2l-multi-select-list>
-						<d2l-multi-select-list-item deletable="" text="List item 0"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" text="List item 1"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" text="List item 2"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" text="List item 3"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" text="List item 4"></d2l-multi-select-list-item>
-						<d2l-multi-select-list-item deletable="" text="List item 5"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" autoremove text="List item 0"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" autoremove text="List item 1"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" autoremove text="List item 2"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" autoremove text="List item 3"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" autoremove text="List item 4"></d2l-multi-select-list-item>
+						<d2l-multi-select-list-item deletable="" autoremove text="List item 5"></d2l-multi-select-list-item>
 					</d2l-multi-select-list>
 				</template>
 			</demo-snippet>


### PR DESCRIPTION
The `this.parentNode.removeChild(this);` line was causing issues when the entries in the list are controlled by a siren API where the element immediately following the deleted tag was also removed. It also means that the tag can disappear even if the delete call fails.

To prevent this, I put this functionality behind an optional autoremove flag.