### PR TITLE
Bracket dat host

### DIFF
--- a/d2l-multi-select-list-item.js
+++ b/d2l-multi-select-list-item.js
@@ -95,7 +95,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-list-item">
 				max-width: 300px;
 			}
 			
-			:host[_fallback-css] d2l-tooltip {
+			:host([_fallback-css]) d2l-tooltip {
 				min-width: 200px;
 			}
 			


### PR DESCRIPTION
Polymer doesn't like [`:host[]` and prefers `:host([])`](https://stackoverflow.com/questions/39290005/polymer-styling-hostattribute-failed)