### PR TITLE
Remove attest dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ addons:
   chrome: stable
 install:
 - npm install
+before_script:
 - curl -u${ARTIFACTORY_USER}:${ARTIFACTORY_PASS} https://d2lartifacts.artifactoryonline.com/d2lartifacts/api/npm/attest/auth/attest
   > .npmrc
-- npm install attest --registry=https://d2lartifacts.artifactoryonline.com/d2lartifacts/api/npm/attest/
+- npm install attest --registry=https://d2lartifacts.artifactoryonline.com/d2lartifacts/api/npm/attest/ --no-save
 script:
 - npm run lint
 - |

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "@polymer/polymer": "^3.0.0",
-    "attest": "^2.7.1",
     "d2l-button": "BrightspaceUI/button#semver:^5",
     "d2l-colors": "BrightspaceUI/colors#semver:^4",
     "d2l-icons": "BrightspaceUI/icons#semver:^6",


### PR DESCRIPTION
`attest` as referenced here is attempting to pull from the npm registry, which only has an attest version up to 1.0.1. And so anything attempting to install this component as a dependency will fail during `npm i`.

It appears this was [added here as a mistake](https://github.com/BrightspaceUI/multi-select/commit/c587c08bb8c5dfad0e6d18720b12be9feccc59a4#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R37), so this PR removes it.