### PR TITLE
fix menu items not keyboard navigable

### DIFF
--- a/d2l-multi-select-list-item.js
+++ b/d2l-multi-select-list-item.js
@@ -87,18 +87,18 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-list-item">
 				margin-left: 0;
 				margin-right: 0.15rem;
 			}
-			
+
 			d2l-tooltip {
 				@apply --d2l-body-small-text;
 				color: var(--d2l-color-white);
 				width: max-content;
 				max-width: 300px;
 			}
-			
+
 			:host([_fallback-css]) d2l-tooltip {
 				min-width: 200px;
 			}
-			
+
 		</style>
 
 		<div class="d2l-multi-select-list-item-wrapper" id="tag" on-click="_onClick">
@@ -110,7 +110,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-list-item">
 			<d2l-tooltip for="tag" position="[[tooltipPosition]]">[[text]]</d2l-tooltip>
 		</template>
 	</template>
-	
+
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);
@@ -218,10 +218,11 @@ class D2LMultiSelectItem extends mixinBehaviors(
 		this.focus();
 	}
 
-	_onDeleteItem() {
+	_onDeleteItem(e) {
+		const handleFocus = e && e.composedPath()[0].tagName === 'D2L-ICON';
 		this.dispatchEvent(new CustomEvent(
 			'd2l-multi-select-list-item-deleted',
-			{ bubbles: true, composed: true, detail: { value: this.text } }
+			{ bubbles: true, composed: true, detail: { value: this.text, handleFocus } }
 		));
 	}
 

--- a/d2l-multi-select-list.js
+++ b/d2l-multi-select-list.js
@@ -120,6 +120,13 @@ class D2LMultiSelectList extends mixinBehaviors(
 	}
 
 	_onListItemDeleted(event) {
+		if (event && event.detail && event.detail.handleFocus) {
+			const rootTarget = event.composedPath()[0];
+			const itemIndex = this.getEffectiveChildren().indexOf(rootTarget);
+			itemIndex === this.getEffectiveChildren().length - 1
+				? this.__focusPrevious(rootTarget)
+				: this.__focusNext(rootTarget);
+		}
 		if (this.autoremove) {
 			event.target.deleteItem();
 		}


### PR DESCRIPTION
Behavior: menu items not keyboard navigable after any item was removed using mouse click

Solution: the menu item using mouse click should be as if it is deleted using `DEL` key. The focus should be sent to the adjacent item.