### PR TITLE
Us108509 - add a new property to show delete icon on hover or focus only

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,23 @@ button.addEventListener('click', () => {
 
 #### `d2l-multi-select-list-item`
 
-`d2l-multi-select-list-item` is a compact representation of information. A `deletable` property can be set to enable the option of deleting the item, although there is no wire-up.
+`d2l-multi-select-list-item` is a compact representation of information.
+
+A `deletable` property can be set to enable the option of deleting the item, although there is no wire-up.
 ```html
 <d2l-multi-select-list-item deletable text="List item"></d2l-multi-select-list-item>
+```
+A 'show-delete-hover-focus' property can be set to allow delete icon to show on hover or focus only.
+```html
+<d2l-multi-select-list-item deletable show-delete-hover-focus text="List item"></d2l-multi-select-list-item>
+```
+Also the following css variables are exposed to clients and can be use to override some of the appearance of the list item.
+```html
+--d2l-multi-select-list-item-font
+--d2l-multi-select-list-item-padding
+--d2l-multi-select-list-item-padding-rtl
+--d2l-multi-select-list-item-padding-deletable
+--d2l-multi-select-list-item-padding-deletable-rtl
 ```
 
 #### `d2l-multi-select-list`

--- a/d2l-multi-select-list-item.js
+++ b/d2l-multi-select-list-item.js
@@ -17,10 +17,14 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-list-item">
 				display: inline-block;
 				outline: none;
 				position: relative;
+				--d2l-multi-select-font: {
+					@apply --d2l-body-compact-text;
+				};
 			}
 
 			.d2l-multi-select-list-item-wrapper {
-				@apply --d2l-body-compact-text;
+				//@apply --d2l-body-compact-text;
+				@apply --d2l-multi-select-font;
 				-moz-user-select: none;
 				-ms-user-select: none;
 				-webkit-user-select: none;
@@ -38,6 +42,11 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-list-item">
 
 			:host([deletable]) .d2l-multi-select-list-item-wrapper {
 				padding-right: 0.4rem;
+			}
+
+			:host(:hover[deletable][show-delete-hover-focus]) .d2l-multi-select-list-item-wrapper d2l-icon,
+			:host(:focus[deletable][show-delete-hover-focus]) .d2l-multi-select-list-item-wrapper d2l-icon {
+				display: flex;
 			}
 
 			:host([dir='rtl'][deletable]) .d2l-multi-select-list-item-wrapper {
@@ -104,7 +113,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-list-item">
 		<div class="d2l-multi-select-list-item-wrapper" id="tag" on-click="_onClick">
 			<div class="d2l-multi-select-list-item-text" aria-hidden="true">[[_getVisibleText(text,shortText,maxChars)]]</div>
 			<d2l-offscreen>[[_getScreenReaderText(text,shortText)]]</d2l-offscreen>
-			<d2l-icon icon="d2l-tier1:close-large-thick" hidden="[[!deletable]]" on-click="_onDeleteItem"></d2l-icon>
+			<d2l-icon icon="d2l-tier1:close-large-thick" hidden="[[_hideDeleteIcon(deletable, showDeleteHoverFocus)]]" on-click="_onDeleteItem"></d2l-icon>
 		</div>
 		<template is="dom-if" if="[[_hasTooltip(text,shortText,maxChars)]]">
 			<d2l-tooltip for="tag" position="[[tooltipPosition]]">[[text]]</d2l-tooltip>
@@ -163,6 +172,14 @@ class D2LMultiSelectItem extends mixinBehaviors(
 			},
 
 			/**
+			* Whether to show delete button on hover or focus only.
+			*/
+			showDeleteHoverFocus: {
+				type: Boolean,
+				value: false
+			},
+
+			/**
 			* The tooltip position
 			*/
 			tooltipPosition: {
@@ -191,6 +208,10 @@ class D2LMultiSelectItem extends mixinBehaviors(
 		super.connectedCallback();
 		// Set tabindex to allow focusable behaviour from the list
 		this.tabIndex = -1;
+	}
+
+	_hideDeleteIcon(deletable, showDeleteHoverFocus) {
+		return !deletable || showDeleteHoverFocus;
 	}
 
 	_hasTooltip(text, shortText, maxChars) {

--- a/d2l-multi-select-list-item.js
+++ b/d2l-multi-select-list-item.js
@@ -23,7 +23,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-list-item">
 			}
 
 			.d2l-multi-select-list-item-wrapper {
-				//@apply --d2l-body-compact-text;
 				@apply --d2l-multi-select-font;
 				-moz-user-select: none;
 				-ms-user-select: none;
@@ -44,9 +43,19 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-list-item">
 				padding-right: 0.4rem;
 			}
 
-			:host(:hover[deletable][show-delete-hover-focus]) .d2l-multi-select-list-item-wrapper d2l-icon,
+			:host([deletable][show-delete-hover-focus]) .d2l-multi-select-list-item-wrapper d2l-icon {
+				visibility: hidden;
+				margin-left: -0.7rem;	
+			}
+
+			:host(:hover[deletable][show-delete-hover-focus]) .d2l-multi-select-list-item-wrapper d2l-icon {
+				visibility: unset;
+				background-color: var(--d2l-color-gypsum);
+			}
+
 			:host(:focus[deletable][show-delete-hover-focus]) .d2l-multi-select-list-item-wrapper d2l-icon {
-				display: flex;
+				visibility: unset;
+				background-color: var(--d2l-color-celestine);
 			}
 
 			:host([dir='rtl'][deletable]) .d2l-multi-select-list-item-wrapper {
@@ -113,7 +122,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-list-item">
 		<div class="d2l-multi-select-list-item-wrapper" id="tag" on-click="_onClick">
 			<div class="d2l-multi-select-list-item-text" aria-hidden="true">[[_getVisibleText(text,shortText,maxChars)]]</div>
 			<d2l-offscreen>[[_getScreenReaderText(text,shortText)]]</d2l-offscreen>
-			<d2l-icon icon="d2l-tier1:close-large-thick" hidden="[[_hideDeleteIcon(deletable, showDeleteHoverFocus)]]" on-click="_onDeleteItem"></d2l-icon>
+			<d2l-icon icon="d2l-tier1:close-large-thick" hidden="[[!deletable]]" on-click="_onDeleteItem"></d2l-icon>
 		</div>
 		<template is="dom-if" if="[[_hasTooltip(text,shortText,maxChars)]]">
 			<d2l-tooltip for="tag" position="[[tooltipPosition]]">[[text]]</d2l-tooltip>
@@ -208,10 +217,6 @@ class D2LMultiSelectItem extends mixinBehaviors(
 		super.connectedCallback();
 		// Set tabindex to allow focusable behaviour from the list
 		this.tabIndex = -1;
-	}
-
-	_hideDeleteIcon(deletable, showDeleteHoverFocus) {
-		return !deletable || showDeleteHoverFocus;
 	}
 
 	_hasTooltip(text, shortText, maxChars) {

--- a/d2l-multi-select-list-item.js
+++ b/d2l-multi-select-list-item.js
@@ -91,12 +91,10 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-multi-select-list-i
 			}
 
 			:host(:focus) .d2l-multi-select-list-item-wrapper d2l-icon {
-				color: #ffffff;
-				opacity: 0.75;
+				color: #c6dbef; // this color is the same as #ffffff with opacity of 0.75
 			}
 
-			:host(:focus) .d2l-multi-select-list-item-wrapper d2l-icon:hover,
-			:host(:focus[show-delete-hover-focus]) .d2l-multi-select-list-item-wrapper d2l-icon {
+            :host(:focus) .d2l-multi-select-list-item-wrapper d2l-icon:hover {
 				color: #ffffff;
 				opacity: 1;
 			}

--- a/d2l-multi-select-list-item.js
+++ b/d2l-multi-select-list-item.js
@@ -9,7 +9,7 @@ import './localize-behavior.js';
 import { mixinBehaviors } from '@polymer/polymer/lib/legacy/class.js';
 
 const $_documentContainer = document.createElement('template');
-$_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-list-item">
+$_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-multi-select-list-item">
 	<template strip-whitespace="">
 		<style>
 			:host {
@@ -17,6 +17,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-list-item">
 				display: inline-block;
 				outline: none;
 				position: relative;
+				--d2l-multi-select-padding: 0.25rem 0.75rem 0.2rem;
+				--d2l-multi-select-padding-rtl: 0.25rem 0.75rem 0.2rem;
+				--d2l-multi-select-padding-deletable: 0.25rem 0.4rem 0.2rem 0.75rem;
+				--d2l-multi-select-padding-deletable-rtl: 0.25rem 0.75rem 0.2rem 0.4rem;
 				--d2l-multi-select-font: {
 					@apply --d2l-body-compact-text;
 				};
@@ -28,7 +32,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-list-item">
 				-ms-user-select: none;
 				-webkit-user-select: none;
 
-				align-items: center;
+				align-items: baseline;
 				background-color: var(--d2l-color-sylvite);
 				border: 1px solid var(--d2l-color-gypsum);
 				border-radius: 0.25rem;
@@ -36,16 +40,25 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-list-item">
 				display: flex;
 				line-height: normal;
 				outline: none;
-				padding: 0.25rem 0.75rem 0.2rem;
+				padding: var(--d2l-multi-select-padding);
+			}
+
+			:host([dir='rtl']) .d2l-multi-select-list-item-wrapper {
+				padding: var(--d2l-multi-select-padding-rtl);
 			}
 
 			:host([deletable]) .d2l-multi-select-list-item-wrapper {
-				padding-right: 0.4rem;
+				padding: var(--d2l-multi-select-padding-deletable);
 			}
 
 			:host([deletable][show-delete-hover-focus]) .d2l-multi-select-list-item-wrapper d2l-icon {
 				visibility: hidden;
-				margin-left: -0.7rem;	
+				margin-left: -0.7rem;
+			}
+
+			:host([dir='rtl'][deletable][show-delete-hover-focus]) .d2l-multi-select-list-item-wrapper d2l-icon {
+				margin-left: 0;
+				margin-right: -0.7rem;
 			}
 
 			:host(:hover[deletable][show-delete-hover-focus]) .d2l-multi-select-list-item-wrapper d2l-icon {
@@ -59,8 +72,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-list-item">
 			}
 
 			:host([dir='rtl'][deletable]) .d2l-multi-select-list-item-wrapper {
-				padding-left: 0.4rem;
-				padding-right: 0.75rem;
+				padding: var(--d2l-multi-select-padding-deletable-rtl);
 			}
 
 			:host(:hover) .d2l-multi-select-list-item-wrapper {
@@ -77,12 +89,14 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-list-item">
 				border-color: var(--d2l-color-celestine-minus-1);
 				color: #ffffff;
 			}
+
 			:host(:focus) .d2l-multi-select-list-item-wrapper d2l-icon {
 				color: #ffffff;
 				opacity: 0.75;
 			}
 
-			:host(:focus) .d2l-multi-select-list-item-wrapper d2l-icon:hover {
+			:host(:focus) .d2l-multi-select-list-item-wrapper d2l-icon:hover,
+			:host(:focus[show-delete-hover-focus]) .d2l-multi-select-list-item-wrapper d2l-icon {
 				color: #ffffff;
 				opacity: 1;
 			}

--- a/d2l-multi-select-list-item.js
+++ b/d2l-multi-select-list-item.js
@@ -17,17 +17,17 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-multi-select-list-i
 				display: inline-block;
 				outline: none;
 				position: relative;
-				--d2l-multi-select-padding: 0.25rem 0.75rem 0.2rem;
-				--d2l-multi-select-padding-rtl: 0.25rem 0.75rem 0.2rem;
-				--d2l-multi-select-padding-deletable: 0.25rem 0.4rem 0.2rem 0.75rem;
-				--d2l-multi-select-padding-deletable-rtl: 0.25rem 0.75rem 0.2rem 0.4rem;
-				--d2l-multi-select-font: {
+				--d2l-multi-select-list-item-padding: 0.25rem 0.75rem 0.2rem;
+				--d2l-multi-select-list-item-padding-rtl: 0.25rem 0.75rem 0.2rem;
+				--d2l-multi-select-list-item-padding-deletable: 0.25rem 0.4rem 0.2rem 0.75rem;
+				--d2l-multi-select-list-item-padding-deletable-rtl: 0.25rem 0.75rem 0.2rem 0.4rem;
+				--d2l-multi-select-list-item-font: {
 					@apply --d2l-body-compact-text;
 				};
 			}
 
 			.d2l-multi-select-list-item-wrapper {
-				@apply --d2l-multi-select-font;
+				@apply --d2l-multi-select-list-item-font;
 				-moz-user-select: none;
 				-ms-user-select: none;
 				-webkit-user-select: none;
@@ -40,15 +40,15 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-multi-select-list-i
 				display: flex;
 				line-height: normal;
 				outline: none;
-				padding: var(--d2l-multi-select-padding);
+				padding: var(--d2l-multi-select-list-item-padding);
 			}
 
 			:host([dir='rtl']) .d2l-multi-select-list-item-wrapper {
-				padding: var(--d2l-multi-select-padding-rtl);
+				padding: var(--d2l-multi-select-list-item-padding-rtl);
 			}
 
 			:host([deletable]) .d2l-multi-select-list-item-wrapper {
-				padding: var(--d2l-multi-select-padding-deletable);
+				padding: var(--d2l-multi-select-list-item-padding-deletable);
 			}
 
 			:host([deletable][show-delete-hover-focus]) .d2l-multi-select-list-item-wrapper d2l-icon {
@@ -72,7 +72,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-multi-select-list-i
 			}
 
 			:host([dir='rtl'][deletable]) .d2l-multi-select-list-item-wrapper {
-				padding: var(--d2l-multi-select-padding-deletable-rtl);
+				padding: var(--d2l-multi-select-list-item-padding-deletable-rtl);
 			}
 
 			:host(:hover) .d2l-multi-select-list-item-wrapper {

--- a/demo/index.html
+++ b/demo/index.html
@@ -96,6 +96,14 @@
 					</d2l-multi-select-list>
 				</template>
 			</demo-snippet>
+			<h3>Show delete icon on hover/focus only</h3>
+			<demo-snippet>
+				<template>
+					<d2l-multi-select-list autoremove>
+						<d2l-multi-select-list-item deletable="" show-delete-hover-focus text="List item 0"></d2l-multi-select-list-item>
+					</d2l-multi-select-list>
+				</template>
+			</demo-snippet>
 		</div>
 
 		<script>

--- a/demo/index_custom_style.html
+++ b/demo/index_custom_style.html
@@ -8,7 +8,7 @@
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
 		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
 		<script type="module" src="../../d2l-typography/d2l-typography.js"></script>
-		
+
 		<script type="module" src="../all-imports.js"></script>
 
 		<script type="module">
@@ -19,7 +19,7 @@
 
 			document.body.appendChild($_documentContainer.content);
 		</script>
-		
+
 		<script type="module">
 			const $_documentContainer = document.createElement('template');
 
@@ -29,7 +29,7 @@
 
 			document.body.appendChild($_documentContainer.content);
 		</script>
-		
+
 		<script type="module">
 			const $_documentContainer = document.createElement('template');
 
@@ -52,19 +52,20 @@
 
 		<custom-style>
 			<style>
-				html {
+				d2l-multi-select-list-item {
+					--d2l-multi-select-padding: 0.1rem 0.1rem 0.1rem 0.3rem;
+					--d2l-multi-select-padding-rtl: 0.1rem 0.3rem 0.1rem 0.1rem;
+					--d2l-multi-select-padding-deletable: 0.1rem 0.1rem 0.1rem 0.3rem;
+					--d2l-multi-select-padding-deletable-rtl: 0.1rem 0.3rem 0.1rem 0.1rem;
 					--d2l-multi-select-font: {
-						font-size: 0.2rem;
-						font-weight: 400;
-						line-height: 1rem;
-						margin: auto;
+						@apply --d2l-body-small-text
 					};
 				}
 			</style>
 		</custom-style>
 	</head>
 	<body class="d2l-typography">
-		<div class="vertical-section-container centered">			
+		<div class="vertical-section-container centered">
 			<h3>Show delete icon on hover/focus only</h3>
 			<demo-snippet>
 				<template>
@@ -77,33 +78,6 @@
 
 		<script>
 			document.body.classList.add('d2l-typography');
-			
-			var runAfterLoadeded = function() {
-				const slottedDemo = document.getElementById('slotted-input-demo');
-				const button = document.getElementById('slotted-input-demo-button');
-				const input = document.getElementById('slotted-input-demo-input');
-
-				if (!slottedDemo || !button || !input) {
-					setTimeout(runAfterLoadeded, 0);
-					return;
-				}
-
-				input.addEventListener('keydown', function(event) {
-					if (event.keyCode === 13 && input.value) {
-						slottedDemo.addItem(input.value);
-						input.value = '';
-					}
-				});
-
-				button.addEventListener('click', function() {
-					if (input.value) {
-						slottedDemo.addItem(input.value);
-						input.value = '';
-					}
-				});
-			};
-			
-			runAfterLoadeded();
 		</script>
 	</body>
 </html>

--- a/demo/index_custom_style.html
+++ b/demo/index_custom_style.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
+		<title>d2l-multi-select demo</title>
+		<script src="../../@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script type="module" src="../../@polymer/iron-demo-helpers/demo-pages-shared-styles.js"></script>
+		<script type="module" src="../../@polymer/iron-demo-helpers/demo-snippet.js"></script>
+		<script type="module" src="../../d2l-typography/d2l-typography.js"></script>
+		
+		<script type="module" src="../all-imports.js"></script>
+
+		<script type="module">
+			const $_documentContainer = document.createElement('template');
+			$_documentContainer.innerHTML = `<custom-style>
+				<style is="custom-style" include="demo-pages-shared-styles"></style>
+			</custom-style>`;
+
+			document.body.appendChild($_documentContainer.content);
+		</script>
+		
+		<script type="module">
+			const $_documentContainer = document.createElement('template');
+
+			$_documentContainer.innerHTML = `<custom-style include="d2l-typography">
+				<style is="custom-style" include="d2l-typography"></style>
+			</custom-style>`;
+
+			document.body.appendChild($_documentContainer.content);
+		</script>
+		
+		<script type="module">
+			const $_documentContainer = document.createElement('template');
+
+			$_documentContainer.innerHTML = `<style>
+						html {
+							font-size: 20px;
+						}
+
+						.custom-input {
+							display: flex;
+						}
+
+						.custom-input input {
+							width: 100%;
+						}
+					</style>`;
+
+			document.body.appendChild($_documentContainer.content);
+		</script>
+
+		<custom-style>
+			<style>
+				html {
+					--d2l-multi-select-font: {
+						font-size: 0.2rem;
+						font-weight: 400;
+						line-height: 1rem;
+						margin: auto;
+					};
+				}
+			</style>
+		</custom-style>
+	</head>
+	<body class="d2l-typography">
+		<div class="vertical-section-container centered">			
+			<h3>Show delete icon on hover/focus only</h3>
+			<demo-snippet>
+				<template>
+					<d2l-multi-select-list autoremove>
+						<d2l-multi-select-list-item deletable="" show-delete-hover-focus text="List item 0"></d2l-multi-select-list-item>
+					</d2l-multi-select-list>
+				</template>
+			</demo-snippet>
+		</div>
+
+		<script>
+			document.body.classList.add('d2l-typography');
+			
+			var runAfterLoadeded = function() {
+				const slottedDemo = document.getElementById('slotted-input-demo');
+				const button = document.getElementById('slotted-input-demo-button');
+				const input = document.getElementById('slotted-input-demo-input');
+
+				if (!slottedDemo || !button || !input) {
+					setTimeout(runAfterLoadeded, 0);
+					return;
+				}
+
+				input.addEventListener('keydown', function(event) {
+					if (event.keyCode === 13 && input.value) {
+						slottedDemo.addItem(input.value);
+						input.value = '';
+					}
+				});
+
+				button.addEventListener('click', function() {
+					if (input.value) {
+						slottedDemo.addItem(input.value);
+						input.value = '';
+					}
+				});
+			};
+			
+			runAfterLoadeded();
+		</script>
+	</body>
+</html>

--- a/demo/index_custom_style.html
+++ b/demo/index_custom_style.html
@@ -53,11 +53,11 @@
 		<custom-style>
 			<style>
 				d2l-multi-select-list-item {
-					--d2l-multi-select-padding: 0.1rem 0.1rem 0.1rem 0.3rem;
-					--d2l-multi-select-padding-rtl: 0.1rem 0.3rem 0.1rem 0.1rem;
-					--d2l-multi-select-padding-deletable: 0.1rem 0.1rem 0.1rem 0.3rem;
-					--d2l-multi-select-padding-deletable-rtl: 0.1rem 0.3rem 0.1rem 0.1rem;
-					--d2l-multi-select-font: {
+					--d2l-multi-select-list-item-padding: 0.1rem 0.1rem 0.1rem 0.3rem;
+					--d2l-multi-select-list-item-padding-rtl: 0.1rem 0.3rem 0.1rem 0.1rem;
+					--d2l-multi-select-list-item-padding-deletable: 0.1rem 0.1rem 0.1rem 0.3rem;
+					--d2l-multi-select-list-item-padding-deletable-rtl: 0.1rem 0.3rem 0.1rem 0.1rem;
+					--d2l-multi-select-list-item-font: {
 						@apply --d2l-body-small-text
 					};
 				}

--- a/test/d2l-multi-select-list-item.html
+++ b/test/d2l-multi-select-list-item.html
@@ -22,6 +22,11 @@
 				<d2l-multi-select-list-item deletable text="deletable-item"></d2l-multi-select-list-item>
 			</template>
 		</test-fixture>
+		<test-fixture id="show-delete-on-hover-or-focus-only">
+			<template>
+				<d2l-multi-select-list-item id='abc' deletable show-delete-hover-focus text="show-delete-on-hover-or-focus-only-item"></d2l-multi-select-list-item>
+			</template>
+		</test-fixture>
 		<script type="module">
 import '../d2l-multi-select-list-item.js';
 describe('<d2l-multi-select-list-item>', function() {
@@ -72,6 +77,21 @@ describe('<d2l-multi-select-list-item>', function() {
 
 			expect(deleteItemSpy.callCount).to.equal(1);
 			expect(deleteItemSpy.args[0][0].detail.value).to.equal('deletable-item');
+		});
+	});
+
+	describe('show delete on hover or focus only', function() {
+		before(function() {
+			item = fixture('show-delete-on-hover-or-focus-only');
+			setItemVariables();
+		});
+
+		it('should pass text parameter correctly', function() {
+			expect(text).to.equal('show-delete-on-hover-or-focus-only-item');
+		});
+
+		it('should not show the delete icon when show-delete-hover-focus attribute is present', function() {
+			expect(deleteIcon.hidden).to.be.true;
 		});
 	});
 

--- a/test/d2l-multi-select-list-item.html
+++ b/test/d2l-multi-select-list-item.html
@@ -22,11 +22,6 @@
 				<d2l-multi-select-list-item deletable text="deletable-item"></d2l-multi-select-list-item>
 			</template>
 		</test-fixture>
-		<test-fixture id="show-delete-on-hover-or-focus-only">
-			<template>
-				<d2l-multi-select-list-item id='abc' deletable show-delete-hover-focus text="show-delete-on-hover-or-focus-only-item"></d2l-multi-select-list-item>
-			</template>
-		</test-fixture>
 		<script type="module">
 import '../d2l-multi-select-list-item.js';
 describe('<d2l-multi-select-list-item>', function() {
@@ -77,21 +72,6 @@ describe('<d2l-multi-select-list-item>', function() {
 
 			expect(deleteItemSpy.callCount).to.equal(1);
 			expect(deleteItemSpy.args[0][0].detail.value).to.equal('deletable-item');
-		});
-	});
-
-	describe('show delete on hover or focus only', function() {
-		before(function() {
-			item = fixture('show-delete-on-hover-or-focus-only');
-			setItemVariables();
-		});
-
-		it('should pass text parameter correctly', function() {
-			expect(text).to.equal('show-delete-on-hover-or-focus-only-item');
-		});
-
-		it('should not show the delete icon when show-delete-hover-focus attribute is present', function() {
-			expect(deleteIcon.hidden).to.be.true;
 		});
 	});
 


### PR DESCRIPTION
Added a new property "show-delete-hover-focus" to allow delete icon only be shown on hover or focus. Also exposed some CSS variables for clients to override some of the cosmetic elements such as padding and font, because our designer wants to have a tag with smaller font size and different padding. 

Requirement and spec:
https://d2lmail.sharepoint.com/:w:/r/sites/wateroutcomesassessment/_layouts/15/Doc.aspx?sourcedoc=%7BF7255365-4F8E-4BDE-BDFF-098B5B41D53A%7D&file=Bulk%20Align%20LOs.docx&action=default&mobileredirect=true


