### PR TITLE
Fix showing tooltip on focus

### DIFF
--- a/d2l-multi-select-list-item.js
+++ b/d2l-multi-select-list-item.js
@@ -141,7 +141,7 @@ $_documentContainer.innerHTML = /*html*/`<dom-module id="d2l-multi-select-list-i
 			<d2l-icon class="d2l-multi-select-delete-icon" icon="d2l-tier1:close-large-thick" hidden="[[!deletable]]" on-click="_onDeleteItem"></d2l-icon>
 		</div>
 		<template is="dom-if" if="[[_hasTooltip(text,shortText,maxChars)]]">
-			<d2l-tooltip for="tag" position="[[tooltipPosition]]">[[text]]</d2l-tooltip>
+			<d2l-tooltip position="[[tooltipPosition]]">[[text]]</d2l-tooltip>
 		</template>
 	</template>
 


### PR DESCRIPTION
This appears to have been the intended behavior all along, but was broken due to some focus issues.

Previously the tooltip was being linked to the inner `d2l-multi-select-list-item-wrapper`, but that element never got focus when the `d2l-multi-select-list-item` was being focused. As a result, the focus handler in the tooltip for the linked element was not firing.
Removing link between the tooltip and the `wrapper` element by removing the `for="tag"`, forces the tooltip to use the parent element `d2l-multi-select-list-item`, which is the element that receives focus (see https://github.com/BrightspaceUI/tooltip/blob/master/d2l-tooltip.js#L287).