### PR TITLE
fixing 2-way binding that doesn't work with Lit

### DIFF
--- a/d2l-multi-select-input-text.js
+++ b/d2l-multi-select-input-text.js
@@ -25,11 +25,12 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-multi-select-input-text">
 				aria-label$="[[ariaLabel]]"
 				aria-labelledby$="[[ariaLabelledby]]"
 				autofocus$="[[autofocus]]"
-				on-keydown="_onKeyDown"
+				on-input="_onInput"
+				on-keypress="_onKeyPress"
 				placeholder$="[[placeholder]]"
 				slot="input"
 				type$="[[type]]"
-				value="{{value}}"
+				value="[[value]]"
 			></d2l-input-text>
 		</d2l-multi-select-input>
 
@@ -86,7 +87,11 @@ class D2LMultiSelectInputText extends PolymerElement {
 		super();
 	}
 
-	_onKeyDown(event) {
+	_onInput(event) {
+		this.value = event.target.value;
+	}
+
+	_onKeyPress(event) {
 		if (event.keyCode === 13 && this.value) {
 			this.$['d2l-multi-select-input'].addItem(this.value, this);
 			this.value = '';


### PR DESCRIPTION
The problem here is that when we upgraded `<d2l-input-text>` to Lit, we didn't realize that places relying on 2-way binding (like this one) would stop working.

Through my code searches, I couldn't find any place actually using this `<d2l-multi-select-input-text>` component.

This PR replaces the 2-way binding with a 1-way and syncs the property using the `on-input` event. I also switched this to use the `keypress` instead of `keydown` event for listening for the ENTER key, as it's more accessible to wait for the key to go down and then up vs. just down.